### PR TITLE
fix: load .env in prisma.config.ts for Prisma 7 compatibility

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,7 +101,7 @@ SplitVibe/
 
 ## Environment Variables
 
-Copy to `.env.local` for local development without Docker. Docker Compose injects these automatically.
+Copy `.env.example` to `.env` for local development without Docker. Docker Compose injects these automatically.
 
 | Variable | Description |
 |----------|-------------|

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ SplitVibe/
 
 ## Environment Variables
 
-Copy to `.env.local` for local development without Docker. Docker Compose injects these automatically.
+Copy `.env.example` to `.env` for local development without Docker. Docker Compose injects these automatically.
 
 | Variable | Description |
 |----------|-------------|

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,4 +1,7 @@
+import dotenv from "dotenv";
 import { defineConfig } from "prisma/config";
+
+dotenv.config();
 
 export default defineConfig({
   datasource: {


### PR DESCRIPTION
## Problem

`npm run db:migrate` fails with:

```
Error: The datasource.url property is required in your Prisma config file when using prisma migrate dev.
```

Prisma 7's `prisma.config.ts` does **not** auto-load `.env` files like older versions did, so `process.env.DATABASE_URL` is `undefined` at config evaluation time.

## Fix

- Add `dotenv.config()` in `prisma.config.ts` to explicitly load `.env` before Prisma reads the datasource URL.
- Fix env-var copy instructions in Copilot and Claude docs (`.env.local` → `.env`).

## Testing

```bash
npm run db:migrate  # ✅ succeeds after this change
```