### PR TITLE
test: validate full CI→validate pipeline (ADR-002)

### DIFF
--- a/docs/adr/002-agentic-ci-workflow.md
+++ b/docs/adr/002-agentic-ci-workflow.md
@@ -2,6 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-03-01
+**Validated:** CI workflow verified (pass + fail paths); validate workflow pending first `workflow_run` trigger.
 
 ---
 


### PR DESCRIPTION
Trivial docs change to trigger the full CI → validate workflow pipeline, now that `validate.yml` exists on `main`.

This PR validates that the `workflow_run` trigger in `validate.yml` fires after CI completes successfully.

Part of #10