### PR TITLE
fix: switch validate workflow to @copilot comment trigger

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,31 +69,19 @@ jobs:
             core.setOutput('count', count);
             core.setOutput('max_reached', count >= max);
 
-      - name: Checkout code
+      - name: Trigger Copilot validation via comment
         if: steps.guard.outputs.max_reached == 'false'
-        uses: actions/checkout@v4
+        uses: actions/github-script@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Setup Node.js
-        if: steps.guard.outputs.max_reached == 'false'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install Copilot CLI
-        if: steps.guard.outputs.max_reached == 'false'
-        run: npm install -g @github/copilot
-
-      - name: Run validate-pr agent
-        if: steps.guard.outputs.max_reached == 'false'
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
-        run: |
-          PR_NUMBER=${{ steps.pr.outputs.number }}
-          copilot -p "Run the validate-pr agent against PR #${PR_NUMBER} in the \
-          marcgs/SplitVibe repository. Post the validation report as a comment \
-          on the PR."
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: '@copilot Run the validate-pr agent against this PR.'
+            });
+            core.info(`Posted @copilot validation trigger on PR #${prNumber}`);
 
       - name: Post max-iterations notice
         if: steps.guard.outputs.max_reached == 'true'


### PR DESCRIPTION
## Problem

The Copilot CLI in programmatic mode (`copilot -p`) runs with a restricted shell sandbox. Most commands fail with "Permission denied":
- `git`, `docker`, `npm`, `curl`, `bash -c`, `python3` — all blocked
- Only file reads (`cat`, `ls`) and GitHub MCP API calls work

The validate-pr agent requires full shell access to set up infrastructure (Docker, dev server) and run E2E tests (Playwright).

## Solution

Replace the direct CLI invocation with an `@copilot` comment trigger. The workflow now:
1. Resolves the PR number (unchanged)
2. Checks the iteration guard (unchanged)
3. Posts `@copilot Run the validate-pr agent against this PR.` as a PR comment
4. The Copilot coding agent picks up the mention and runs in a full VM with unrestricted shell access

### Benefits
- **Full shell access** — coding agent VM supports Docker, git, npm, Playwright
- **No PAT required** — uses built-in `GITHUB_TOKEN` instead of `COPILOT_PAT` secret
- **Simpler workflow** — removed checkout, Node.js setup, and CLI install steps

### Tradeoff
- **Non-deterministic timing** — depends on Copilot monitoring PR comments (typically seconds to minutes)

## Changes
- `.github/workflows/validate.yml` — replaced CLI steps with `@copilot` comment
- `docs/adr/002-agentic-ci-workflow.md` — updated Layer 3 description, alternatives, consequences

Part of #10