### PR TITLE
fix(ci): use COPILOT_PAT for @copilot trigger comment

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,6 +73,9 @@ jobs:
         if: steps.guard.outputs.max_reached == 'false'
         uses: actions/github-script@v7
         with:
+          # Use a real-user PAT so the @copilot mention is not ignored
+          # (the coding agent ignores bot-authored mentions).
+          github-token: ${{ secrets.COPILOT_PAT }}
           script: |
             const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Problem

The validate workflow posts an `@copilot` comment using the built-in `GITHUB_TOKEN`, which makes the comment appear from `github-actions[bot]`. The Copilot coding agent ignores bot-authored mentions to prevent infinite loops, so validation never triggers.

## Solution

Use `COPILOT_PAT` (a real-user fine-grained PAT stored as a repository secret) to post the trigger comment. This makes the mention come from a real user, which the coding agent responds to.

### Changes
- **`.github/workflows/validate.yml`**: Added `github-token: ${{ secrets.COPILOT_PAT }}` to the trigger comment step
- **`docs/adr/002-agentic-ci-workflow.md`**: Updated to document PAT requirement, removed incorrect "No PAT required" claim, added PAT rotation risk

## Testing

This PR needs to be merged to `main` first (validate.yml triggers from the default branch), then tested by rebasing PR #31.

Closes #10 (partial — implements CI pass/fail gate)