### PR TITLE
fix(ci): improve @copilot trigger to invoke validate-pr skill

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,7 +82,14 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: '@copilot Run the validate-pr agent against this PR.'
+              body: [
+                '@copilot Use the **validate-pr** skill on this PR.',
+                '',
+                'Instructions:',
+                '- Invoke the `validate-pr` skill (defined in `.github/agents/validate-pr.agent.md`).',
+                '- The skill will validate acceptance criteria and post a **Validation Report** comment on this PR.',
+                '- **Do NOT create a new branch or open a new pull request.** Only post the validation report as a comment here.',
+              ].join('\n')
             });
             core.info(`Posted @copilot validation trigger on PR #${prNumber}`);
 


### PR DESCRIPTION
The previous `@copilot` trigger comment was too vague, causing the coding agent to open sub-PRs instead of running the validate-pr skill and posting results as a comment.

Updated the comment to explicitly:
- Reference the `validate-pr` skill by name
- Instruct the agent to post results as a comment
- Instruct the agent NOT to create branches/PRs