### PR TITLE
infra: set minReplicas=1 for prod to avoid cold starts

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -44,6 +44,9 @@ param customDomain string = ''
 @description('Container port (default 3000 for SplitVibe; use 80 for placeholder quickstart image)')
 param targetPort int = 3000
 
+@description('Minimum number of container replicas (set to 1 for prod to avoid cold-start delays)')
+param minReplicas int = 0
+
 @description('Google OAuth client ID (optional — supply when ready to enable Google sign-in)')
 param authGoogleId string = ''
 
@@ -235,6 +238,7 @@ module containerApps 'modules/containerApps.bicep' = {
     managedIdentityId: managedIdentity.outputs.id
     managedIdentityClientId: managedIdentity.outputs.clientId
     targetPort: targetPort
+    minReplicas: minReplicas
   }
 }
 

--- a/infra/parameters/prod.parameters.json
+++ b/infra/parameters/prod.parameters.json
@@ -13,6 +13,9 @@
     },
     "postgresAdminLogin": {
       "value": "splitvibeadmin"
+    },
+    "minReplicas": {
+      "value": 1
     }
   }
 }


### PR DESCRIPTION
## Summary
- Wire `minReplicas` parameter through `main.bicep` to the container apps module (defaults to `0`)
- Set `minReplicas: 1` in `prod.parameters.json` so prod always keeps one warm replica
- Dev stays at `0` to save costs

## Context
After idle periods, Azure scales the container app to zero replicas. The next request triggers a full cold start (container provisioning + image pull + Node boot + migration check), causing multi-second latency.

## Test plan
- [ ] Verify `bin/sv deploy prod` completes successfully
- [ ] Confirm the container app shows 1 running replica after deployment
- [ ] Verify no cold-start delay after idle period

🤖 Generated with [Claude Code](https://claude.com/claude-code)