### PR TITLE
feat: add Vercel as alternative deployment target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,5 +44,16 @@ FX_API_BASE_URL="https://api.frankfurter.app"
 # --- Next.js ---
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
+# --- Vercel Deployment ---
+# BUILD_TARGET is set automatically in the Dockerfile for Azure Container Apps.
+# When deploying to Vercel, leave it unset (Vercel uses its default build adapter).
+# BUILD_TARGET=docker
+
+# For Vercel + Azure Blob Storage, use a connection string (Managed Identity is not available):
+# AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+
+# For Vercel + Neon (alternative to Azure PostgreSQL):
+# DATABASE_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/splitvibe?sslmode=require"
+
 # --- Misc ---
 ENABLE_TEST_ACCOUNTS=true   # Enable mock login buttons for local dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+ENV BUILD_TARGET=docker
 RUN npx prisma generate
 RUN npm run build
 

--- a/bin/commands/deploy-vercel.sh
+++ b/bin/commands/deploy-vercel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ENV="${1:-}"
+if [ -z "$ENV" ] || { [ "$ENV" != "dev" ] && [ "$ENV" != "prod" ]; }; then
+  echo "Usage: bin/sv deploy-vercel <dev|prod>" >&2
+  exit 1
+fi
+
+# Source .env if present
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+# Check vercel CLI is installed
+if ! command -v vercel &>/dev/null; then
+  echo "==> Error: vercel CLI not found. Install with: npm i -g vercel" >&2
+  exit 1
+fi
+
+# Validate required env vars
+missing=()
+[ -z "${DATABASE_URL:-}" ] && missing+=("DATABASE_URL")
+[ -z "${AUTH_SECRET:-}" ] && missing+=("AUTH_SECRET")
+[ -z "${AUTH_GOOGLE_ID:-}" ] && missing+=("AUTH_GOOGLE_ID")
+[ -z "${AUTH_GOOGLE_SECRET:-}" ] && missing+=("AUTH_GOOGLE_SECRET")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "==> Error: missing required environment variables:" >&2
+  for var in "${missing[@]}"; do
+    echo "    - $var" >&2
+  done
+  exit 1
+fi
+
+# Run migrations against the target database
+echo "==> Running database migrations..."
+npx prisma migrate deploy
+
+# Deploy to Vercel
+if [ "$ENV" = "prod" ]; then
+  echo "==> Deploying to Vercel (production)..."
+  vercel deploy --prod
+else
+  echo "==> Deploying to Vercel (preview)..."
+  vercel deploy
+fi
+
+echo "==> Vercel deployment complete."

--- a/bin/commands/env-vercel.sh
+++ b/bin/commands/env-vercel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ENV="${1:-}"
+if [ -z "$ENV" ] || { [ "$ENV" != "dev" ] && [ "$ENV" != "prod" ]; }; then
+  echo "Usage: bin/sv env-vercel <dev|prod>" >&2
+  exit 1
+fi
+
+# Check vercel CLI is installed
+if ! command -v vercel &>/dev/null; then
+  echo "==> Error: vercel CLI not found. Install with: npm i -g vercel" >&2
+  exit 1
+fi
+
+VERCEL_ENV="preview"
+[ "$ENV" = "prod" ] && VERCEL_ENV="production"
+
+# Source .env if present
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+VARS=(
+  DATABASE_URL
+  AUTH_SECRET
+  AUTH_GOOGLE_ID
+  AUTH_GOOGLE_SECRET
+  AZURE_STORAGE_CONNECTION_STRING
+  AZURE_STORAGE_CONTAINER_NAME
+  NEXT_PUBLIC_APP_URL
+)
+
+echo "==> Syncing environment variables to Vercel ($VERCEL_ENV)..."
+for var in "${VARS[@]}"; do
+  val="${!var:-}"
+  if [ -n "$val" ]; then
+    echo "$val" | vercel env add "$var" "$VERCEL_ENV" --force 2>/dev/null
+    echo "    Set $var"
+  else
+    echo "    Skipped $var (not set)"
+  fi
+done
+
+echo "==> Done."

--- a/bin/sv
+++ b/bin/sv
@@ -17,7 +17,9 @@ Commands:
   test [args]        Run tests (--e2e, --watch, path)
   check              Full quality gate (typecheck -> lint -> test)
   lint [file]        Typecheck + lint (project-wide or single file)
-  deploy <env>       Build, push, deploy (dev|prod)
+  deploy <env>       Build, push, deploy to Azure (dev|prod)
+  deploy-vercel <env> Deploy to Vercel (dev|prod)
+  env-vercel <env>   Sync environment variables to Vercel (dev|prod)
   infra <env>        Provision Azure infrastructure (dev|prod)
   domain <env>       Bind custom domain + TLS (dev|prod)
   check-env-leak     Scan diff for leaked .env values

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "standalone",
+  ...(process.env.BUILD_TARGET === "docker" ? { output: "standalone" } : {}),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",


### PR DESCRIPTION
Add `bin/sv deploy-vercel` and `bin/sv env-vercel` commands for deploying
to Vercel alongside the existing Azure Container Apps setup. Make
`output: "standalone"` conditional on BUILD_TARGET=docker so Vercel uses
its default build adapter while Docker builds remain unchanged.

https://claude.ai/code/session_01W2KCmVfzPYRFRu4aMvLFqk