### PR TITLE
expense edit & delete (Copilot CLI - implement skill)

### DIFF
--- a/app/(app)/groups/[id]/expense-row-actions.tsx
+++ b/app/(app)/groups/[id]/expense-row-actions.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Member {
+  userId: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+}
+
+interface ExpenseRowActionsProps {
+  expenseId: string;
+  groupId: string;
+  members: Member[];
+  initialTitle: string;
+  initialAmount: number;
+  initialPaidBy: string;
+  initialSplitAmong: string[];
+  initialDate: string;
+}
+
+export default function ExpenseRowActions({
+  expenseId,
+  members,
+  initialTitle,
+  initialAmount,
+  initialPaidBy,
+  initialSplitAmong,
+  initialDate,
+}: ExpenseRowActionsProps) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState(initialTitle);
+  const [amount, setAmount] = useState(String(initialAmount));
+  const [paidBy, setPaidBy] = useState(initialPaidBy);
+  const [splitAmong, setSplitAmong] = useState<string[]>(initialSplitAmong);
+  const [date, setDate] = useState(initialDate);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function toggleSplitMember(userId: string) {
+    setSplitAmong((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/expenses/${expenseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          amount: parseFloat(amount),
+          paidBy,
+          splitAmong,
+          date,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "Failed to update expense");
+        return;
+      }
+      setEditing(false);
+      router.refresh();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete this expense? Balances will be recalculated.")) {
+      return;
+    }
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/expenses/${expenseId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "Failed to delete expense");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="text-xs text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={loading}
+          className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300"
+        >
+          {loading ? "Deleting…" : "Delete"}
+        </button>
+        {error && (
+          <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="mt-3 space-y-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Title
+        </label>
+        <input
+          type="text"
+          required
+          maxLength={200}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Amount
+        </label>
+        <input
+          type="number"
+          required
+          min="0.01"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Paid by
+        </label>
+        <select
+          value={paidBy}
+          onChange={(e) => setPaidBy(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        >
+          {members.map((m) => (
+            <option key={m.userId} value={m.userId}>
+              {m.user.name ?? m.user.email}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Split among
+        </label>
+        <div className="space-y-1">
+          {members.map((m) => (
+            <label key={m.userId} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={splitAmong.includes(m.userId)}
+                onChange={() => toggleSplitMember(m.userId)}
+                className="rounded border-zinc-300 dark:border-zinc-700"
+              />
+              {m.user.name ?? m.user.email}
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Date
+        </label>
+        <input
+          type="date"
+          required
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={loading || !title.trim() || !amount || splitAmong.length === 0}
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {loading ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(false);
+            setError("");
+            setTitle(initialTitle);
+            setAmount(String(initialAmount));
+            setPaidBy(initialPaidBy);
+            setSplitAmong(initialSplitAmong);
+            setDate(initialDate);
+          }}
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -9,6 +9,7 @@ import ExpenseForm from "./expense-form";
 import SettlementForm from "./settlement-form";
 import DeleteSettlementButton from "./delete-settlement-button";
 import ExpenseAttachments from "./expense-attachments";
+import ExpenseRowActions from "./expense-row-actions";
 
 export default async function GroupDetailPage({
   params,
@@ -19,6 +20,7 @@ export default async function GroupDetailPage({
   if (!session?.user?.id) {
     notFound();
   }
+  const currentUserId = session.user.id;
 
   const { id } = await params;
 
@@ -237,6 +239,18 @@ export default async function GroupDetailPage({
                     expenseId={expense.id}
                     attachments={expense.attachments}
                   />
+                  {expense.createdById === currentUserId && (
+                    <ExpenseRowActions
+                      expenseId={expense.id}
+                      groupId={group.id}
+                      members={group.members}
+                      initialTitle={expense.description}
+                      initialAmount={Number(expense.amount)}
+                      initialPaidBy={expense.payers[0]?.userId ?? currentUserId}
+                      initialSplitAmong={expense.splits.map((s) => s.userId)}
+                      initialDate={new Date(expense.date).toISOString().split("T")[0]}
+                    />
+                  )}
                 </div>
               ))}
             </div>

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { z } from "zod";
 
-const createExpenseSchema = z.object({
+const updateExpenseSchema = z.object({
   title: z.string().min(1).max(200),
   amount: z.number().positive(),
   paidBy: z.string().min(1),
@@ -13,7 +13,7 @@ const createExpenseSchema = z.object({
   }),
 });
 
-export async function POST(
+export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -22,16 +22,18 @@ export async function POST(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { id: groupId } = await params;
+  const { id: expenseId } = await params;
 
-  // Check membership
-  const membership = await db.groupMember.findUnique({
-    where: {
-      groupId_userId: { groupId, userId: session.user.id },
-    },
+  const expense = await db.expense.findUnique({
+    where: { id: expenseId },
+    select: { id: true, groupId: true, createdById: true, deletedAt: true },
   });
 
-  if (!membership) {
+  if (!expense || expense.deletedAt !== null) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (expense.createdById !== session.user.id) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -42,7 +44,7 @@ export async function POST(
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const parsed = createExpenseSchema.safeParse(body);
+  const parsed = updateExpenseSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Validation failed", details: parsed.error.flatten() },
@@ -52,9 +54,8 @@ export async function POST(
 
   const { title, amount, paidBy, splitAmong, date } = parsed.data;
 
-  // Verify paidBy and all splitAmong users are group members
   const groupMembers = await db.groupMember.findMany({
-    where: { groupId },
+    where: { groupId: expense.groupId },
     include: { user: { select: { id: true, name: true, email: true } } },
   });
 
@@ -76,13 +77,11 @@ export async function POST(
     }
   }
 
-  // Convert amount to cents (integer) for equal split calculation
   const amountCents = Math.round(amount * 100);
   const participantCount = splitAmong.length;
   const baseSplitCents = Math.floor(amountCents / participantCount);
   const remainderCents = amountCents - baseSplitCents * participantCount;
 
-  // Sort participants alphabetically by name (then email) to determine who gets remainder
   const participantMembers = groupMembers
     .filter((m) => splitAmong.includes(m.userId))
     .sort((a, b) => {
@@ -100,39 +99,41 @@ export async function POST(
     };
   });
 
-  const expense = await db.expense.create({
-    data: {
-      groupId,
-      createdById: session.user.id,
-      description: title,
-      amount,
-      currency: "USD",
-      splitMode: "EQUAL",
-      date: new Date(date),
-      payers: {
-        create: {
-          userId: paidBy,
-          amount,
+  const updated = await db.$transaction(async (tx) => {
+    await tx.expensePayer.deleteMany({ where: { expenseId } });
+    await tx.expenseSplit.deleteMany({ where: { expenseId } });
+
+    return tx.expense.update({
+      where: { id: expenseId },
+      data: {
+        description: title,
+        amount,
+        date: new Date(date),
+        payers: {
+          create: {
+            userId: paidBy,
+            amount,
+          },
+        },
+        splits: {
+          create: splitData,
         },
       },
-      splits: {
-        create: splitData,
+      include: {
+        payers: {
+          include: { user: { select: { id: true, name: true, email: true } } },
+        },
+        splits: {
+          include: { user: { select: { id: true, name: true, email: true } } },
+        },
       },
-    },
-    include: {
-      payers: {
-        include: { user: { select: { id: true, name: true, email: true } } },
-      },
-      splits: {
-        include: { user: { select: { id: true, name: true, email: true } } },
-      },
-    },
+    });
   });
 
-  return NextResponse.json(expense, { status: 201 });
+  return NextResponse.json(updated);
 }
 
-export async function GET(
+export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -141,31 +142,25 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { id: groupId } = await params;
+  const { id: expenseId } = await params;
 
-  // Check membership
-  const membership = await db.groupMember.findUnique({
-    where: {
-      groupId_userId: { groupId, userId: session.user.id },
-    },
+  const expense = await db.expense.findUnique({
+    where: { id: expenseId },
+    select: { id: true, createdById: true, deletedAt: true },
   });
 
-  if (!membership) {
+  if (!expense || expense.deletedAt !== null) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (expense.createdById !== session.user.id) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const expenses = await db.expense.findMany({
-    where: { groupId, deletedAt: null },
-    include: {
-      payers: {
-        include: { user: { select: { id: true, name: true, email: true } } },
-      },
-      splits: {
-        include: { user: { select: { id: true, name: true, email: true } } },
-      },
-    },
-    orderBy: { date: "desc" },
+  const deleted = await db.expense.update({
+    where: { id: expenseId },
+    data: { deletedAt: new Date() },
   });
 
-  return NextResponse.json(expenses);
+  return NextResponse.json(deleted);
 }

--- a/prisma/migrations/20260418190424_add_expense_creator/migration.sql
+++ b/prisma/migrations/20260418190424_add_expense_creator/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN     "createdById" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Expense_createdById_idx" ON "Expense"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,11 +24,12 @@ model User {
 
   accounts     Account[]
   sessions     Session[]
-  groupMembers GroupMember[]
-  paidExpenses ExpensePayer[]
-  splits       ExpenseSplit[]
-  settlements  Settlement[]   @relation("SettlementPayer")
-  receivables  Settlement[]   @relation("SettlementPayee")
+  groupMembers     GroupMember[]
+  paidExpenses     ExpensePayer[]
+  splits           ExpenseSplit[]
+  createdExpenses  Expense[]      @relation("ExpenseCreator")
+  settlements      Settlement[]   @relation("SettlementPayer")
+  receivables      Settlement[]   @relation("SettlementPayee")
 }
 
 model Account {
@@ -108,6 +109,7 @@ model GroupMember {
 model Expense {
   id                 String    @id @default(cuid())
   groupId            String
+  createdById        String?
   description        String
   amount             Decimal   @db.Decimal(14, 4)
   currency           String
@@ -122,9 +124,12 @@ model Expense {
   deletedAt          DateTime?
 
   group       Group          @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  createdBy   User?          @relation("ExpenseCreator", fields: [createdById], references: [id], onDelete: SetNull)
   payers      ExpensePayer[]
   splits      ExpenseSplit[]
   attachments Attachment[]
+
+  @@index([createdById])
 }
 
 model ExpensePayer {

--- a/tests/expense-update-delete-api.test.ts
+++ b/tests/expense-update-delete-api.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------- mocks --------------------------------------------------------
+
+const mockSession = {
+  user: { id: "user-1", name: "Alice", email: "alice@splitvibe.dev" },
+};
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(() => Promise.resolve(mockSession)),
+}));
+
+const mockTx = {
+  expensePayer: { deleteMany: vi.fn() },
+  expenseSplit: { deleteMany: vi.fn() },
+  expense: { update: vi.fn() },
+};
+
+const mockDb = {
+  groupMember: { findMany: vi.fn() },
+  expense: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  $transaction: vi.fn(
+    async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)
+  ),
+};
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+// ---------- helpers ------------------------------------------------------
+
+function jsonRequest(body: unknown, method: string = "PATCH"): Request {
+  return new Request("http://localhost/api/expenses/exp-1", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const defaultParams = { params: Promise.resolve({ id: "exp-1" }) };
+
+const threeMembers = [
+  {
+    userId: "user-1",
+    user: { id: "user-1", name: "Alice", email: "alice@splitvibe.dev" },
+  },
+  {
+    userId: "user-2",
+    user: { id: "user-2", name: "Bob", email: "bob@splitvibe.dev" },
+  },
+  {
+    userId: "user-3",
+    user: { id: "user-3", name: "Carol", email: "carol@splitvibe.dev" },
+  },
+];
+
+const validBody = {
+  title: "Dinner",
+  amount: 60,
+  paidBy: "user-1",
+  splitAmong: ["user-1", "user-2", "user-3"],
+  date: "2025-06-15",
+};
+
+// ---------- PATCH tests --------------------------------------------------
+
+describe("PATCH /api/expenses/[id]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(mockSession as never);
+    mockDb.$transaction.mockImplementation(
+      async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)
+    );
+  });
+
+  it("updates the expense and recomputes splits when creator edits", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockTx.expense.update.mockResolvedValue({
+      id: "exp-1",
+      description: "Dinner",
+      amount: 60,
+    });
+
+    const res = await PATCH(jsonRequest(validBody), defaultParams);
+    expect(res.status).toBe(200);
+
+    expect(mockTx.expensePayer.deleteMany).toHaveBeenCalledWith({
+      where: { expenseId: "exp-1" },
+    });
+    expect(mockTx.expenseSplit.deleteMany).toHaveBeenCalledWith({
+      where: { expenseId: "exp-1" },
+    });
+
+    const updateCall = mockTx.expense.update.mock.calls[0][0];
+    const splits = updateCall.data.splits.create;
+    expect(splits).toHaveLength(3);
+    expect(splits.every((s: { amount: number }) => s.amount === 20)).toBe(true);
+    expect(updateCall.data.payers.create).toEqual({
+      userId: "user-1",
+      amount: 60,
+    });
+    expect(updateCall.data.amount).toBe(60);
+    expect(updateCall.data.description).toBe("Dinner");
+  });
+
+  it("uses a transaction so split replacement is atomic", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockTx.expense.update.mockResolvedValue({ id: "exp-1" });
+
+    await PATCH(jsonRequest(validBody), defaultParams);
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 when a non-creator tries to edit", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-2",
+      deletedAt: null,
+    });
+
+    const res = await PATCH(jsonRequest(validBody), defaultParams);
+    expect(res.status).toBe(403);
+    expect(mockTx.expense.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the expense does not exist", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(null);
+
+    const res = await PATCH(jsonRequest(validBody), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the expense is already soft-deleted", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: new Date(),
+    });
+
+    const res = await PATCH(jsonRequest(validBody), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when payer is not a group member", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+
+    const res = await PATCH(
+      jsonRequest({ ...validBody, paidBy: "non-member" }),
+      defaultParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when validation fails", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+
+    const res = await PATCH(
+      jsonRequest({ ...validBody, amount: -1 }),
+      defaultParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      groupId: "grp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+
+    const req = new Request("http://localhost/api/expenses/exp-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await PATCH(req, defaultParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(null as never);
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+
+    const res = await PATCH(jsonRequest(validBody), defaultParams);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------- DELETE tests -------------------------------------------------
+
+describe("DELETE /api/expenses/[id]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(mockSession as never);
+  });
+
+  it("soft-deletes the expense by setting deletedAt", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      createdById: "user-1",
+      deletedAt: null,
+    });
+    mockDb.expense.update.mockResolvedValue({
+      id: "exp-1",
+      deletedAt: new Date(),
+    });
+
+    const res = await DELETE(
+      new Request("http://localhost/api/expenses/exp-1", { method: "DELETE" }),
+      defaultParams
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockDb.expense.update).toHaveBeenCalledWith({
+      where: { id: "exp-1" },
+      data: { deletedAt: expect.any(Date) },
+    });
+  });
+
+  it("returns 403 when a non-creator tries to delete", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      createdById: "user-2",
+      deletedAt: null,
+    });
+
+    const res = await DELETE(
+      new Request("http://localhost/api/expenses/exp-1", { method: "DELETE" }),
+      defaultParams
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockDb.expense.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when expense does not exist", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(
+      new Request("http://localhost/api/expenses/exp-1", { method: "DELETE" }),
+      defaultParams
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when expense is already soft-deleted", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue({
+      id: "exp-1",
+      createdById: "user-1",
+      deletedAt: new Date(),
+    });
+
+    const res = await DELETE(
+      new Request("http://localhost/api/expenses/exp-1", { method: "DELETE" }),
+      defaultParams
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(null as never);
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+
+    const res = await DELETE(
+      new Request("http://localhost/api/expenses/exp-1", { method: "DELETE" }),
+      defaultParams
+    );
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
Implements story 10 — the expense creator can edit any field of their expense or soft-delete it; balances recalculate automatically.

## Changes
- **Schema:** added `createdById` (nullable FK to `User`, `ON DELETE SET NULL`) + index on `Expense`. Migration: `20260418190424_add_expense_creator`.
- **POST `/api/groups/[id]/expenses`** now persists `createdById = session.user.id`.
- **PATCH `/api/expenses/[id]`** (new): creator-only (403 otherwise). Validates body with Zod, re-checks group membership of payer + splitAmong, then atomically replaces `ExpensePayer` and `ExpenseSplit` rows inside `db.$transaction` and updates the expense. Splits use the same cents-floor + alphabetical-remainder logic as POST.
- **DELETE `/api/expenses/[id]`** (new): creator-only soft delete — sets `deletedAt`. Already-deleted or missing expenses return 404. The row stays in the DB.
- **UI:** group detail page now renders inline Edit / Delete actions under each expense, but only for rows where `createdById === currentUserId`. Editing opens an inline form; deleting prompts `confirm()` then refreshes. Soft-deleted expenses are already excluded by the existing `where: { deletedAt: null }` filter, so they disappear from the list immediately.

## Tests
- `tests/expense-update-delete-api.test.ts` — 14 new test cases covering: successful update + atomic split replacement, transaction usage, 403 for non-creator, 404 for missing/deleted, 400 for invalid payer / validation / JSON, 401 unauth, plus DELETE happy path and all error cases.
- Full `bin/sv check` is green: typecheck ✅ · lint ✅ · 124/124 tests ✅.

## Acceptance criteria mapping
- ✅ Editing a $90 expense to $60 updates balances — PATCH replaces splits and the existing balance pipeline reads the updated values.
- ✅ Only the creator can edit/delete — `createdById !== session.user.id` → 403.
- ✅ Deleted expense hidden from the UI list — server query filters `deletedAt: null`.
- ✅ Row remains in DB with `deletedAt` populated — DELETE uses `expense.update({ data: { deletedAt: new Date() } })`.