### PR TITLE
expense edit & delete (Copilot CLI)

### DIFF
--- a/app/(app)/groups/[id]/expense-actions.tsx
+++ b/app/(app)/groups/[id]/expense-actions.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Member {
+  userId: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+}
+
+interface ExpenseActionsProps {
+  expenseId: string;
+  groupId: string;
+  members: Member[];
+  initialTitle: string;
+  initialAmount: number;
+  initialPaidBy: string;
+  initialSplitAmong: string[];
+  initialDate: string;
+}
+
+export default function ExpenseActions({
+  expenseId,
+  members,
+  initialTitle,
+  initialAmount,
+  initialPaidBy,
+  initialSplitAmong,
+  initialDate,
+}: ExpenseActionsProps) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState(initialTitle);
+  const [amount, setAmount] = useState(initialAmount.toFixed(2));
+  const [paidBy, setPaidBy] = useState(initialPaidBy);
+  const [splitAmong, setSplitAmong] = useState<string[]>(initialSplitAmong);
+  const [date, setDate] = useState(initialDate);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function toggleSplitMember(userId: string) {
+    setSplitAmong((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete this expense? This cannot be undone.")) return;
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/expenses/${expenseId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? "Failed to delete expense");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/expenses/${expenseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          amount: parseFloat(amount),
+          paidBy,
+          splitAmong,
+          date,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? "Failed to update expense");
+        return;
+      }
+      setEditing(false);
+      router.refresh();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="text-xs text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={loading}
+          className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300"
+        >
+          {loading ? "Deleting…" : "Delete"}
+        </button>
+        {error && (
+          <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="mt-3 space-y-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Title
+        </label>
+        <input
+          type="text"
+          required
+          maxLength={200}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Amount (USD)
+        </label>
+        <input
+          type="number"
+          required
+          min="0.01"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Paid by
+        </label>
+        <select
+          value={paidBy}
+          onChange={(e) => setPaidBy(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        >
+          {members.map((m) => (
+            <option key={m.userId} value={m.userId}>
+              {m.user.name ?? m.user.email}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Split among
+        </label>
+        <div className="space-y-1">
+          {members.map((m) => (
+            <label key={m.userId} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={splitAmong.includes(m.userId)}
+                onChange={() => toggleSplitMember(m.userId)}
+                className="rounded border-zinc-300 dark:border-zinc-700"
+              />
+              {m.user.name ?? m.user.email}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          Date
+        </label>
+        <input
+          type="date"
+          required
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={loading || !title.trim() || !amount || splitAmong.length === 0}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {loading ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(false);
+            setError("");
+            setTitle(initialTitle);
+            setAmount(initialAmount.toFixed(2));
+            setPaidBy(initialPaidBy);
+            setSplitAmong(initialSplitAmong);
+            setDate(initialDate);
+          }}
+          disabled={loading}
+          className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -9,6 +9,7 @@ import ExpenseForm from "./expense-form";
 import SettlementForm from "./settlement-form";
 import DeleteSettlementButton from "./delete-settlement-button";
 import ExpenseAttachments from "./expense-attachments";
+import ExpenseActions from "./expense-actions";
 
 export default async function GroupDetailPage({
   params,
@@ -19,6 +20,7 @@ export default async function GroupDetailPage({
   if (!session?.user?.id) {
     notFound();
   }
+  const sessionUserId = session.user.id;
 
   const { id } = await params;
 
@@ -237,6 +239,18 @@ export default async function GroupDetailPage({
                     expenseId={expense.id}
                     attachments={expense.attachments}
                   />
+                  {expense.createdById === sessionUserId && (
+                    <ExpenseActions
+                      expenseId={expense.id}
+                      groupId={group.id}
+                      members={group.members}
+                      initialTitle={expense.description}
+                      initialAmount={Number(expense.amount)}
+                      initialPaidBy={expense.payers[0]?.userId ?? sessionUserId}
+                      initialSplitAmong={expense.splits.map((s) => s.userId)}
+                      initialDate={new Date(expense.date).toISOString().split("T")[0]}
+                    />
+                  )}
                 </div>
               ))}
             </div>

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,0 +1,257 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+const patchExpenseSchema = z
+  .object({
+    title: z.string().min(1).max(200).optional(),
+    amount: z.number().positive().optional(),
+    paidBy: z.string().min(1).optional(),
+    splitAmong: z.array(z.string().min(1)).min(1).optional(),
+    date: z
+      .string()
+      .refine((v) => !isNaN(Date.parse(v)), { message: "Invalid date" })
+      .optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+interface GroupMemberWithUser {
+  userId: string;
+  user: { id: string; name: string | null; email: string };
+}
+
+function computeEqualSplits(
+  amount: number,
+  participants: GroupMemberWithUser[]
+): { userId: string; amount: number }[] {
+  const amountCents = Math.round(amount * 100);
+  const n = participants.length;
+  const baseCents = Math.floor(amountCents / n);
+  const remainderCents = amountCents - baseCents * n;
+
+  const sorted = [...participants].sort((a, b) => {
+    const nameA = (a.user.name ?? a.user.email).toLowerCase();
+    const nameB = (b.user.name ?? b.user.email).toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+
+  return sorted.map((member, i) => ({
+    userId: member.userId,
+    amount: (baseCents + (i < remainderCents ? 1 : 0)) / 100,
+  }));
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: expenseId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = patchExpenseSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const expense = await db.expense.findUnique({
+    where: { id: expenseId },
+    select: {
+      id: true,
+      groupId: true,
+      createdById: true,
+      amount: true,
+      deletedAt: true,
+    },
+  });
+
+  if (!expense || expense.deletedAt !== null) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Legacy rows without a recorded creator cannot be mutated.
+  if (expense.createdById === null || expense.createdById !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Creator must still be a member of the group.
+  const membership = await db.groupMember.findUnique({
+    where: {
+      groupId_userId: { groupId: expense.groupId, userId: session.user.id },
+    },
+  });
+  if (!membership) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { title, amount, paidBy, splitAmong, date } = parsed.data;
+
+  let splitData: { userId: string; amount: number }[] | null = null;
+  let payerData: { userId: string; amount: number } | null = null;
+
+  const newAmount = amount ?? Number(expense.amount);
+
+  if (splitAmong !== undefined || amount !== undefined || paidBy !== undefined) {
+    const groupMembers = await db.groupMember.findMany({
+      where: { groupId: expense.groupId },
+      include: { user: { select: { id: true, name: true, email: true } } },
+    });
+    const memberUserIds = new Set(groupMembers.map((m) => m.userId));
+
+    if (paidBy !== undefined && !memberUserIds.has(paidBy)) {
+      return NextResponse.json(
+        { error: "Payer is not a group member" },
+        { status: 400 }
+      );
+    }
+
+    if (splitAmong !== undefined) {
+      const uniqueIds = new Set(splitAmong);
+      if (uniqueIds.size !== splitAmong.length) {
+        return NextResponse.json(
+          { error: "splitAmong contains duplicate user IDs" },
+          { status: 400 }
+        );
+      }
+      for (const userId of splitAmong) {
+        if (!memberUserIds.has(userId)) {
+          return NextResponse.json(
+            { error: `User ${userId} is not a group member` },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    if (splitAmong !== undefined || amount !== undefined) {
+      let participantIds: string[];
+      if (splitAmong !== undefined) {
+        participantIds = splitAmong;
+      } else {
+        const existingSplits = await db.expenseSplit.findMany({
+          where: { expenseId },
+          select: { userId: true },
+        });
+        participantIds = existingSplits.map((s) => s.userId);
+      }
+      const participants = groupMembers.filter((m) =>
+        participantIds.includes(m.userId)
+      );
+      if (participants.length === 0) {
+        return NextResponse.json(
+          { error: "No valid participants" },
+          { status: 400 }
+        );
+      }
+      splitData = computeEqualSplits(newAmount, participants);
+    }
+
+    if (paidBy !== undefined || amount !== undefined) {
+      const payerId =
+        paidBy ??
+        (
+          await db.expensePayer.findFirst({
+            where: { expenseId },
+            select: { userId: true },
+          })
+        )?.userId;
+      if (!payerId) {
+        return NextResponse.json(
+          { error: "Existing payer not found" },
+          { status: 400 }
+        );
+      }
+      payerData = { userId: payerId, amount: newAmount };
+    }
+  }
+
+  const updated = await db.$transaction(async (tx) => {
+    if (splitData !== null) {
+      await tx.expenseSplit.deleteMany({ where: { expenseId } });
+      await tx.expenseSplit.createMany({
+        data: splitData.map((s) => ({ ...s, expenseId })),
+      });
+    }
+    if (payerData !== null) {
+      await tx.expensePayer.deleteMany({ where: { expenseId } });
+      await tx.expensePayer.create({
+        data: { ...payerData, expenseId },
+      });
+    }
+    return tx.expense.update({
+      where: { id: expenseId },
+      data: {
+        ...(title !== undefined ? { description: title } : {}),
+        ...(amount !== undefined ? { amount } : {}),
+        ...(date !== undefined ? { date: new Date(date) } : {}),
+      },
+      include: {
+        payers: {
+          include: { user: { select: { id: true, name: true, email: true } } },
+        },
+        splits: {
+          include: { user: { select: { id: true, name: true, email: true } } },
+        },
+      },
+    });
+  });
+
+  return NextResponse.json(updated, { status: 200 });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: expenseId } = await params;
+
+  const expense = await db.expense.findUnique({
+    where: { id: expenseId },
+    select: { id: true, groupId: true, createdById: true, deletedAt: true },
+  });
+
+  if (!expense || expense.deletedAt !== null) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (expense.createdById === null || expense.createdById !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const membership = await db.groupMember.findUnique({
+    where: {
+      groupId_userId: { groupId: expense.groupId, userId: session.user.id },
+    },
+  });
+  if (!membership) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const deleted = await db.expense.update({
+    where: { id: expenseId },
+    data: { deletedAt: new Date() },
+  });
+
+  return NextResponse.json(deleted, { status: 200 });
+}

--- a/app/api/groups/[id]/expenses/route.ts
+++ b/app/api/groups/[id]/expenses/route.ts
@@ -103,6 +103,7 @@ export async function POST(
   const expense = await db.expense.create({
     data: {
       groupId,
+      createdById: session.user.id,
       description: title,
       amount,
       currency: "USD",

--- a/prisma/migrations/20260418202222_expense_creator/migration.sql
+++ b/prisma/migrations/20260418202222_expense_creator/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN     "createdById" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Expense_createdById_idx" ON "Expense"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,11 +24,12 @@ model User {
 
   accounts     Account[]
   sessions     Session[]
-  groupMembers GroupMember[]
-  paidExpenses ExpensePayer[]
-  splits       ExpenseSplit[]
-  settlements  Settlement[]   @relation("SettlementPayer")
-  receivables  Settlement[]   @relation("SettlementPayee")
+  groupMembers    GroupMember[]
+  paidExpenses    ExpensePayer[]
+  splits          ExpenseSplit[]
+  createdExpenses Expense[]      @relation("ExpenseCreator")
+  settlements     Settlement[]   @relation("SettlementPayer")
+  receivables     Settlement[]   @relation("SettlementPayee")
 }
 
 model Account {
@@ -108,6 +109,7 @@ model GroupMember {
 model Expense {
   id                 String    @id @default(cuid())
   groupId            String
+  createdById        String?
   description        String
   amount             Decimal   @db.Decimal(14, 4)
   currency           String
@@ -122,9 +124,12 @@ model Expense {
   deletedAt          DateTime?
 
   group       Group          @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  createdBy   User?          @relation("ExpenseCreator", fields: [createdById], references: [id])
   payers      ExpensePayer[]
   splits      ExpenseSplit[]
   attachments Attachment[]
+
+  @@index([createdById])
 }
 
 model ExpensePayer {

--- a/tests/expense-detail-api.test.ts
+++ b/tests/expense-detail-api.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------- mocks --------------------------------------------------------
+
+const mockSession = {
+  user: { id: "user-1", name: "Alice", email: "alice@splitvibe.dev" },
+};
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(() => Promise.resolve(mockSession)),
+}));
+
+const mockTx = {
+  expenseSplit: {
+    deleteMany: vi.fn(),
+    createMany: vi.fn(),
+  },
+  expensePayer: {
+    deleteMany: vi.fn(),
+    create: vi.fn(),
+  },
+  expense: {
+    update: vi.fn(),
+  },
+};
+
+const mockDb = {
+  groupMember: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+  expense: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  expenseSplit: {
+    findMany: vi.fn(),
+  },
+  expensePayer: {
+    findFirst: vi.fn(),
+  },
+  $transaction: vi.fn(
+    async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)
+  ),
+};
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+// ---------- helpers ------------------------------------------------------
+
+function jsonRequest(body: unknown, method: "PATCH" | "DELETE" = "PATCH"): Request {
+  return new Request("http://localhost/api/expenses/exp-1", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const defaultParams = { params: Promise.resolve({ id: "exp-1" }) };
+
+const threeMembers = [
+  { userId: "user-1", user: { id: "user-1", name: "Alice", email: "alice@splitvibe.dev" } },
+  { userId: "user-2", user: { id: "user-2", name: "Bob", email: "bob@splitvibe.dev" } },
+  { userId: "user-3", user: { id: "user-3", name: "Carol", email: "carol@splitvibe.dev" } },
+];
+
+function existingExpense(overrides: Partial<{
+  createdById: string | null;
+  deletedAt: Date | null;
+  amount: number;
+  groupId: string;
+}> = {}) {
+  return {
+    id: "exp-1",
+    groupId: "grp-1",
+    createdById: "user-1",
+    amount: 90,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+// ---------- PATCH tests --------------------------------------------------
+
+describe("PATCH /api/expenses/[id]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(mockSession as never);
+    mockDb.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)
+    );
+  });
+
+  it("updates amount from $90 to $60 and replaces splits with $20/$20/$20", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockDb.expenseSplit.findMany.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+      { userId: "user-3" },
+    ]);
+    mockDb.expensePayer.findFirst.mockResolvedValue({ userId: "user-1" });
+    mockTx.expense.update.mockResolvedValue({ id: "exp-1", amount: 60 });
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(200);
+
+    expect(mockTx.expenseSplit.deleteMany).toHaveBeenCalledWith({
+      where: { expenseId: "exp-1" },
+    });
+    const createdSplits = mockTx.expenseSplit.createMany.mock.calls[0][0].data;
+    expect(createdSplits).toHaveLength(3);
+    expect(createdSplits.every((s: { amount: number }) => s.amount === 20)).toBe(true);
+
+    expect(mockTx.expensePayer.deleteMany).toHaveBeenCalledWith({
+      where: { expenseId: "exp-1" },
+    });
+    const payerCreate = mockTx.expensePayer.create.mock.calls[0][0].data;
+    expect(payerCreate).toEqual({
+      expenseId: "exp-1",
+      userId: "user-1",
+      amount: 60,
+    });
+  });
+
+  it("re-distributes remainder cents alphabetically when amount changes", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockDb.expenseSplit.findMany.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+      { userId: "user-3" },
+    ]);
+    mockDb.expensePayer.findFirst.mockResolvedValue({ userId: "user-1" });
+    mockTx.expense.update.mockResolvedValue({ id: "exp-1" });
+
+    const res = await PATCH(jsonRequest({ amount: 100 }), defaultParams);
+    expect(res.status).toBe(200);
+
+    const splits = mockTx.expenseSplit.createMany.mock.calls[0][0].data;
+    const alice = splits.find((s: { userId: string }) => s.userId === "user-1");
+    const bob = splits.find((s: { userId: string }) => s.userId === "user-2");
+    const carol = splits.find((s: { userId: string }) => s.userId === "user-3");
+    expect(alice.amount).toBeCloseTo(33.34, 2);
+    expect(bob.amount).toBeCloseTo(33.33, 2);
+    expect(carol.amount).toBeCloseTo(33.33, 2);
+  });
+
+  it("updates only the title without touching splits or payers", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockTx.expense.update.mockResolvedValue({ id: "exp-1", description: "Brunch" });
+
+    const res = await PATCH(jsonRequest({ title: "Brunch" }), defaultParams);
+    expect(res.status).toBe(200);
+
+    expect(mockTx.expenseSplit.deleteMany).not.toHaveBeenCalled();
+    expect(mockTx.expensePayer.deleteMany).not.toHaveBeenCalled();
+    const updateData = mockTx.expense.update.mock.calls[0][0].data;
+    expect(updateData).toEqual({ description: "Brunch" });
+  });
+
+  it("changes splitAmong subset and computes correct splits", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense({ amount: 90 }));
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockDb.expensePayer.findFirst.mockResolvedValue({ userId: "user-1" });
+    mockTx.expense.update.mockResolvedValue({ id: "exp-1" });
+
+    const res = await PATCH(
+      jsonRequest({ splitAmong: ["user-1", "user-2"] }),
+      defaultParams
+    );
+    expect(res.status).toBe(200);
+
+    const splits = mockTx.expenseSplit.createMany.mock.calls[0][0].data;
+    expect(splits).toHaveLength(2);
+    expect(splits.every((s: { amount: number }) => s.amount === 45)).toBe(true);
+  });
+
+  it("returns 403 when current user is not the creator", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ createdById: "user-2" })
+    );
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(403);
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when expense has no recorded creator (legacy row)", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ createdById: null })
+    );
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when creator is no longer a group member", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue(null);
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when expense does not exist", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(null);
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when expense is already soft-deleted", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ deletedAt: new Date() })
+    );
+
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    const req = new Request("http://localhost/api/expenses/exp-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await PATCH(req, defaultParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when no fields are provided", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    const res = await PATCH(jsonRequest({}), defaultParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when amount is non-positive", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    const res = await PATCH(jsonRequest({ amount: 0 }), defaultParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when splitAmong contains duplicates", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+
+    const res = await PATCH(
+      jsonRequest({ splitAmong: ["user-1", "user-1", "user-2"] }),
+      defaultParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when paidBy is not a group member", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+
+    const res = await PATCH(
+      jsonRequest({ paidBy: "outsider" }),
+      defaultParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a splitAmong user is not a group member", async () => {
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+
+    const res = await PATCH(
+      jsonRequest({ splitAmong: ["user-1", "outsider"] }),
+      defaultParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(null as never);
+    const { PATCH } = await import("@/app/api/expenses/[id]/route");
+    const res = await PATCH(jsonRequest({ amount: 60 }), defaultParams);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------- DELETE tests -------------------------------------------------
+
+describe("DELETE /api/expenses/[id]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(mockSession as never);
+  });
+
+  it("soft-deletes by setting deletedAt and returns the updated row", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.expense.update.mockResolvedValue({
+      id: "exp-1",
+      deletedAt: new Date(),
+    });
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(200);
+
+    const updateCall = mockDb.expense.update.mock.calls[0][0];
+    expect(updateCall.where).toEqual({ id: "exp-1" });
+    expect(updateCall.data.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("returns 403 when current user is not the creator", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ createdById: "user-2" })
+    );
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(403);
+    expect(mockDb.expense.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for legacy expenses with no recorded creator", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ createdById: null })
+    );
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when creator is no longer a group member", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(existingExpense());
+    mockDb.groupMember.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when expense does not exist", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when expense is already soft-deleted", async () => {
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    mockDb.expense.findUnique.mockResolvedValue(
+      existingExpense({ deletedAt: new Date() })
+    );
+
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const authMod = vi.mocked(await import("@/lib/auth"));
+    authMod.auth.mockResolvedValue(null as never);
+    const { DELETE } = await import("@/app/api/expenses/[id]/route");
+    const res = await DELETE(jsonRequest({}, "DELETE"), defaultParams);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/expenses-api.test.ts
+++ b/tests/expenses-api.test.ts
@@ -156,6 +156,27 @@ describe("POST /api/groups/[id]/expenses", () => {
     expect(payers.amount).toBe(90);
   });
 
+  it("creates an expense with createdById set to the session user", async () => {
+    const { POST } = await import("@/app/api/groups/[id]/expenses/route");
+    mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });
+    mockDb.groupMember.findMany.mockResolvedValue(threeMembers);
+    mockDb.expense.create.mockResolvedValue({ id: "exp-1" });
+
+    await POST(
+      jsonRequest({
+        title: "Dinner",
+        amount: 90,
+        paidBy: "user-1",
+        splitAmong: ["user-1", "user-2", "user-3"],
+        date: "2025-06-15",
+      }),
+      defaultParams
+    );
+
+    const createCall = mockDb.expense.create.mock.calls[0][0];
+    expect(createCall.data.createdById).toBe("user-1");
+  });
+
   it("returns 400 when title is missing", async () => {
     const { POST } = await import("@/app/api/groups/[id]/expenses/route");
     mockDb.groupMember.findUnique.mockResolvedValue({ role: "member" });


### PR DESCRIPTION
Closes #12.

## Summary

Implements editing and soft-deleting of expenses by their creator, with automatic balance recalculation.

## Changes

### Schema (`prisma/schema.prisma` + new migration)
- Adds nullable `Expense.createdById` with relation `User \"ExpenseCreator\"` (`ON DELETE SET NULL`).
- Existing expenses with `createdById = null` are treated as immutable (PATCH/DELETE return 403) since we cannot prove who created them.

### API
- **`POST /api/groups/[id]/expenses`** — now stamps `createdById` from the session.
- **`PATCH /api/expenses/[id]`** *(new)* — partial update. Replaces \`ExpensePayer\` and \`ExpenseSplit\` rows atomically inside a single \`db.\$transaction\`, recomputing equal splits when amount or splitAmong changes (alphabetical remainder distribution per project rules). Validates uniqueness of \`splitAmong\` and group membership of \`paidBy\` / split users.
- **`DELETE /api/expenses/[id]`** *(new)* — sets \`deletedAt\`. The Expense row remains in the DB.
- **Authorization** for both: requires the caller to be the recorded creator AND a current member of the group. Removed members and non-creators get 403.

### UI
- New client component \`expense-actions.tsx\`. Each expense row in the group page now renders an \"Edit / Delete\" toolbar visible only to the creator. Edit toggles an inline form that PATCHes the expense; Delete confirms and DELETEs.
- The expense list query already filters \`deletedAt: null\`, so soft-deleted expenses disappear from the UI immediately after deletion (and from balance calculations).

## Tests
- New \`tests/expense-detail-api.test.ts\` (23 cases) covering PATCH and DELETE: success, balance-impact (\$90→\$60 ⇒ three \$20 splits, \$100/3 remainder cents to alphabetically first), 403 for non-creator / legacy / removed member, 404 for missing / already-deleted, 400 for bad JSON / no fields / non-positive amount / duplicate splitAmong / non-member paidBy or split user, 401 unauthenticated.
- Extended \`tests/expenses-api.test.ts\` to assert \`createdById\` is stamped on POST.
- Full quality gate (\`bin/sv check\`) passes — typecheck, lint, **134/134** tests green.

## Acceptance criteria mapping
- ✅ Editing a \$90 expense to \$60 updates balances accordingly — covered by the \"\$90→\$60 ⇒ three \$20 splits\" test plus existing balance-recalc on the page.
- ✅ Only the expense creator can edit or delete; other members receive a 403 — covered by 403 tests + UI gating on \`createdById === sessionUserId\`.
- ✅ A deleted expense is hidden from the UI — group page query filters \`deletedAt: null\`.
- ✅ The Expense row still exists in the DB with \`deletedAt\` populated — DELETE uses \`db.expense.update\`, not \`delete\`.

## Notes for reviewers
- I deliberately denied mutations on legacy \`createdById = null\` rows rather than inferring the creator from the first payer (which could grant edit rights to the wrong user).
- PATCH currently only re-derives equal splits; PERCENTAGE / SHARES split modes are out of scope for this story (still EQUAL on the underlying schema).

session id: 136446a5-c4de-4718-baa7-42b2a047fc09