### PR TITLE
docs(agents): make implement→validate-pr handoff work in cloud agent

### DIFF
--- a/.github/agents/implement.agent.md
+++ b/.github/agents/implement.agent.md
@@ -137,22 +137,34 @@ Create a pull request on GitHub with:
 
 ### 9. Validate the PR
 
-After the PR is created, invoke the **validate-pr-agent** via the `task`
-tool to verify that all acceptance criteria are met. Copilot CLI custom
-agents are invoked programmatically through the `task` tool with
-`agent_type` — not via `@mention` chat syntax (in Copilot CLI, `@` mentions
-files and `#` mentions issues/PRs).
+After the PR is created, **invoke the `validate-pr-agent` custom agent**
+to verify that all acceptance criteria are met. **This step is mandatory
+— do not proceed to step 10 until validation has been invoked and a
+result is available.**
 
-Example invocation:
+Use whichever tool your runtime exposes for invoking another custom agent:
 
-```
-task(
-  agent_type: "validate-pr-agent",
-  name: "validate-pr",
-  description: "Validate PR acceptance criteria",
-  prompt: "Validate PR #<pr-number> against the linked issue's acceptance criteria."
-)
-```
+- **Copilot CLI:** use the `task` tool with
+  `agent_type: "validate-pr-agent"`. Example:
+  ```
+  task(
+    agent_type: "validate-pr-agent",
+    name: "validate-pr",
+    description: "Validate PR acceptance criteria",
+    prompt: "Validate PR #<pr-number> against the linked issue's acceptance criteria."
+  )
+  ```
+- **Copilot cloud agent (GitHub.com):** use the `agent` tool (also
+  aliased as `Task` / `custom-agent`) and invoke the custom agent named
+  `validate-pr-agent` with the prompt:
+  `"Validate PR #<pr-number> against the linked issue's acceptance criteria."`
+- **Copilot in IDEs (VS Code, JetBrains, etc.):** use the equivalent
+  custom-agent invocation tool exposed by the IDE runtime, naming
+  `validate-pr-agent` and passing the same prompt.
+
+Note: in Copilot CLI, `@` mentions files and `#` mentions issues/PRs —
+custom agents are **not** invoked via `@mention` chat syntax in any
+runtime. Always invoke them through the runtime's custom-agent tool.
 
 The validate-pr-agent will **post its validation report as a comment on the
 PR** (see validate-pr-agent Step 7). Ensure the full report table, summary, and
@@ -169,6 +181,11 @@ comment already exists, it should be updated rather than duplicated.
   push, and re-validate.
 
 ### 10. Final report
+
+**Do not produce this report until step 9 has actually been executed and
+the validate-pr-agent has returned a result (or definitively failed to
+run).** If validation was not invoked, return to step 9 and invoke it
+before reporting.
 
 ```markdown
 ## Implementation Report — Issue #<number>
@@ -190,3 +207,9 @@ comment already exists, it should be updated rather than duplicated.
 ### PR: #<pr-number> — <pr-title>
 ### Validation: ✅ All acceptance criteria verified
 ```
+
+The `Validation` row and the final `Validation:` line **must** reflect
+the actual outcome returned by validate-pr-agent in step 9. If the
+validate-pr-agent could not be invoked in this runtime, mark the row
+⚠️ and explain which custom-agent invocation tool was missing — do not
+silently report success.

--- a/.github/agents/implement.agent.md
+++ b/.github/agents/implement.agent.md
@@ -162,10 +162,6 @@ Use whichever tool your runtime exposes for invoking another custom agent:
   custom-agent invocation tool exposed by the IDE runtime, naming
   `validate-pr-agent` and passing the same prompt.
 
-Note: in Copilot CLI, `@` mentions files and `#` mentions issues/PRs —
-custom agents are **not** invoked via `@mention` chat syntax in any
-runtime. Always invoke them through the runtime's custom-agent tool.
-
 The validate-pr-agent will **post its validation report as a comment on the
 PR** (see validate-pr-agent Step 7). Ensure the full report table, summary, and
 conclusion are visible in the PR timeline so reviewers can see the


### PR DESCRIPTION
## Problem

In cloud Copilot agent sessions (e.g. PR #70), `implement-agent` opens the PR and then ends without invoking `validate-pr-agent` — so no validation comment is ever posted.

## Root cause

Step 9 of `.github/agents/implement.agent.md` instructs the model to call:

```
task(agent_type: "validate-pr-agent", ...)
```

That is the **Copilot CLI** tool signature. The **cloud agent runtime** exposes the same capability as the `agent` tool (aliases `Task` / `custom-agent`) per the [official custom-agents reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration#tool-aliases). The CLI-specific name doesn't match anything in the cloud runtime, so the call is skipped silently and the agent moves on to step 10 (final report) and exits.

Compounding this, step 10's report template was reachable without validation having run — giving the model a clean exit ramp.

## Changes

- **Step 9:** describe the invocation tool per runtime (CLI `task`, cloud `agent`, IDEs) and mark the step **mandatory**.
- **Step 10:** gate the final report on step 9 having actually executed; require honest reporting if the validate-pr-agent could not be invoked.

## Verification

Cannot be verified until next implement-agent run. Look for:
- A `validate-pr-agent` invocation in the cloud session log.
- A validation report comment on the resulting PR.

Closes nothing — this is a tooling fix.