### PR TITLE
docs(adr-002): document GH_TOKEN-in-copilot-env for validate-pr comments

### DIFF
--- a/.github/agents/validate-pr.agent.md
+++ b/.github/agents/validate-pr.agent.md
@@ -145,69 +145,15 @@ Execute each criterion using its assigned strategy:
 ### 8. Post results to the PR
 
 After producing the validation report, **post it as a comment on the
-PR in GitHub** containing the full report from step 7.
+PR in GitHub**. Use the GitHub API (or the available GitHub MCP tools)
+to add an issue comment on the pull request with the full report from
+step 6.
 
-#### Authentication
-
-The default token available to the cloud Copilot agent (and to the
-out-of-the-box `github` MCP server) is **read-only on pull requests** —
-attempting to comment with it returns
-`GraphQL: Resource not accessible by integration (addComment)` /
-`HTTP 403`.
-
-A repo-scoped fine-grained PAT with **Pull requests: Read and write** is
-exposed to the agent's runtime as the `COPILOT_PAT` environment variable
-via the `copilot` GitHub Actions environment. **Always use this token
-when posting to the PR**, never the default `gh` / MCP credentials.
-
-#### How to post
-
-Prefer `gh` over raw `curl` so the body is escaped correctly. Write the
-report to a file first to avoid shell-quoting issues with the markdown
-table:
-
-```bash
-# Write the full report (table + summary + conclusion) to a file.
-cat > /tmp/validation-report.md <<'EOF'
-## Validation Report — PR #<number>
-... (full report from step 7) ...
-EOF
-
-# Look for an existing validation comment from a previous run.
-existing_id=$(GH_TOKEN="$COPILOT_PAT" gh pr view <pr-number> \
-  --repo marcgs/SplitVibe --json comments \
-  --jq '.comments[] | select(.body | startswith("## Validation Report — PR #")) | .id' \
-  | head -n 1)
-
-if [ -n "$existing_id" ]; then
-  # Update the existing comment in place.
-  GH_TOKEN="$COPILOT_PAT" gh api \
-    --method PATCH \
-    "/repos/marcgs/SplitVibe/issues/comments/$existing_id" \
-    -f body="$(cat /tmp/validation-report.md)"
-else
-  # Create a new comment.
-  GH_TOKEN="$COPILOT_PAT" gh pr comment <pr-number> \
-    --repo marcgs/SplitVibe \
-    --body-file /tmp/validation-report.md
-fi
-```
-
-Notes:
-
-- Always pass the token as `GH_TOKEN="$COPILOT_PAT"` on the command line —
-  do not rely on `gh auth login`, and do not call the `github` MCP server
-  for write operations (it uses the read-only token).
-- If `$COPILOT_PAT` is unset (e.g. when the agent is invoked from a
-  local Copilot CLI / Claude Code session that already has a personal
-  `gh auth` token), fall back to plain `gh pr comment …` without the
-  `GH_TOKEN=` prefix.
-- The comment must contain the complete report table, summary, and
-  conclusion so reviewers can see the validation status directly in the
-  PR timeline without re-running the agent.
-- If a previous validation comment exists, **update it** rather than
-  creating a duplicate (the snippet above does this automatically by
-  matching the `## Validation Report — PR #` prefix).
+- If a previous validation comment from this agent already exists on
+  the PR, **update it** instead of creating a duplicate.
+- The comment should contain the complete report table, summary, and
+  conclusion so that reviewers can see the validation status directly
+  in the PR timeline without re-running the agent.
 
 ### 9. Tear down the dev environment
 

--- a/.github/agents/validate-pr.agent.md
+++ b/.github/agents/validate-pr.agent.md
@@ -145,15 +145,69 @@ Execute each criterion using its assigned strategy:
 ### 8. Post results to the PR
 
 After producing the validation report, **post it as a comment on the
-PR in GitHub**. Use the GitHub API (or the available GitHub MCP tools)
-to add an issue comment on the pull request with the full report from
-step 6.
+PR in GitHub** containing the full report from step 7.
 
-- If a previous validation comment from this agent already exists on
-  the PR, **update it** instead of creating a duplicate.
-- The comment should contain the complete report table, summary, and
-  conclusion so that reviewers can see the validation status directly
-  in the PR timeline without re-running the agent.
+#### Authentication
+
+The default token available to the cloud Copilot agent (and to the
+out-of-the-box `github` MCP server) is **read-only on pull requests** —
+attempting to comment with it returns
+`GraphQL: Resource not accessible by integration (addComment)` /
+`HTTP 403`.
+
+A repo-scoped fine-grained PAT with **Pull requests: Read and write** is
+exposed to the agent's runtime as the `COPILOT_PAT` environment variable
+via the `copilot` GitHub Actions environment. **Always use this token
+when posting to the PR**, never the default `gh` / MCP credentials.
+
+#### How to post
+
+Prefer `gh` over raw `curl` so the body is escaped correctly. Write the
+report to a file first to avoid shell-quoting issues with the markdown
+table:
+
+```bash
+# Write the full report (table + summary + conclusion) to a file.
+cat > /tmp/validation-report.md <<'EOF'
+## Validation Report — PR #<number>
+... (full report from step 7) ...
+EOF
+
+# Look for an existing validation comment from a previous run.
+existing_id=$(GH_TOKEN="$COPILOT_PAT" gh pr view <pr-number> \
+  --repo marcgs/SplitVibe --json comments \
+  --jq '.comments[] | select(.body | startswith("## Validation Report — PR #")) | .id' \
+  | head -n 1)
+
+if [ -n "$existing_id" ]; then
+  # Update the existing comment in place.
+  GH_TOKEN="$COPILOT_PAT" gh api \
+    --method PATCH \
+    "/repos/marcgs/SplitVibe/issues/comments/$existing_id" \
+    -f body="$(cat /tmp/validation-report.md)"
+else
+  # Create a new comment.
+  GH_TOKEN="$COPILOT_PAT" gh pr comment <pr-number> \
+    --repo marcgs/SplitVibe \
+    --body-file /tmp/validation-report.md
+fi
+```
+
+Notes:
+
+- Always pass the token as `GH_TOKEN="$COPILOT_PAT"` on the command line —
+  do not rely on `gh auth login`, and do not call the `github` MCP server
+  for write operations (it uses the read-only token).
+- If `$COPILOT_PAT` is unset (e.g. when the agent is invoked from a
+  local Copilot CLI / Claude Code session that already has a personal
+  `gh auth` token), fall back to plain `gh pr comment …` without the
+  `GH_TOKEN=` prefix.
+- The comment must contain the complete report table, summary, and
+  conclusion so reviewers can see the validation status directly in the
+  PR timeline without re-running the agent.
+- If a previous validation comment exists, **update it** rather than
+  creating a duplicate (the snippet above does this automatically by
+  matching the `## Validation Report — PR #` prefix).
 
 ### 9. Tear down the dev environment
 

--- a/docs/adr/002-agentic-ci-workflow.md
+++ b/docs/adr/002-agentic-ci-workflow.md
@@ -60,12 +60,12 @@ Current workarounds for re-validation:
   Issue assigned to Copilot
          │
          ▼
-  ┌────────────────────────────────────┐
-  │  implement agent                    │
-  │  (TDD + self-check)                 │
-  │  Step 9: validate-pr custom agent   │
-  │  → posts report on PR (GH_TOKEN PAT) │
-  └──────────┬─────────────────────────┘
+  ┌───────────────────────────────────┐
+  │  implement agent                   │
+  │  (TDD + self-check)                │
+  │  Step 9: validate-pr custom agent  │
+  │  → posts report on PR (via PAT)    │
+  └──────────┬────────────────────────┘
              │ Opens PR
              ▼
   ┌─────────────────────────────────┐
@@ -159,7 +159,7 @@ Same as Approach 2, but the comment is posted using a real-user fine-grained PAT
 **Result:** The coding agent **picked up the mention** (responded within seconds). However, its hardcoded behavior when mentioned on a PR is to **always create a sub-PR** — it opened empty draft PRs (#37, #40) targeting the original PR's branch. Despite explicit instructions ("Do NOT create a new branch or open a new pull request. Only post the validation report as a comment here."), the agent:
 - Created a sub-branch (e.g., `copilot/sub-pr-31-again`)
 - Opened a draft sub-PR
-- Did **not** invoke the validate-pr skill
+- Did **not** invoke the validate-pr custom agent
 - Did **not** post a validation report on the original PR
 
 This appears to be a fundamental design constraint of the Copilot coding agent when triggered via PR comments — it always operates in "implementation mode" (create branch → make changes → open PR), not "comment-only mode."
@@ -216,7 +216,7 @@ The workflow itself would run: `docker compose up` → `npm run dev` → Playwri
 ### Positive
 
 - **Fast feedback** — deterministic CI catches type errors, lint issues, and test failures in minutes on every push.
-- **No secrets required** — CI uses only `GITHUB_TOKEN`. No PAT management or rotation.
+- **Layer 2 needs no secrets** — CI uses only the workflow's built-in `GITHUB_TOKEN`. Layer 1 requires a single fine-grained PAT (`GH_TOKEN` in the `copilot` environment) for posting validation comments — see [Operational requirements](#operational-requirements).
 - **Simple and reliable** — no agentic dependencies, no non-deterministic timing, no sub-PR noise.
 - **E2E validation at implementation time** — the implement agent's Step 9 provides full acceptance-criteria validation (Docker, Playwright, AI reasoning) during the initial implementation cycle.
 - **Visible audit trail** — CI results are standard GitHub status checks. Validation reports from the implement agent are posted as PR comments.
@@ -229,6 +229,7 @@ The workflow itself would run: `docker compose up` → `npm run dev` → Playwri
 ### Risks
 
 - **Regression after post-implementation pushes** — a human or Copilot push that breaks acceptance criteria won't be caught automatically (only CI regressions are caught). Mitigated by human review before merge.
+- **PAT expiration** — the `GH_TOKEN` PAT in the `copilot` environment has a finite expiration (max 1 year for fine-grained PATs). If it lapses, validate-pr Step 8 will start returning HTTP 403 again with no other functional impact. Mitigation: rotate before expiry; the failure mode is loud and obvious in the next implement-agent run.
 - **Platform evolution** — GitHub may add support for coding agent "comment-only" responses or a public API to trigger agent sessions without sub-PRs. When this happens, Layer 3 should be revisited.
 
 ### Deferred Work

--- a/docs/adr/002-agentic-ci-workflow.md
+++ b/docs/adr/002-agentic-ci-workflow.md
@@ -30,7 +30,7 @@ Triggered by assigning a GitHub issue to Copilot (or invoking the implement agen
 
 1. The **implement** agent reads the issue, creates a feature branch, implements via TDD, runs its own validation loop, and opens a PR with `Closes #N`.
 2. In Step 9, the implement agent invokes the **validate-pr** custom agent within the same coding agent session (via the `agent` / `Task` tool — see [Custom agents reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration#tool-aliases)). This runs in a full VM with Docker, git, npm, and Playwright MCP — providing complete E2E acceptance-criteria validation.
-3. The validation report is posted as a comment on the PR by validate-pr Step 8, authenticated with the `COPILOT_PAT` fine-grained PAT (see [Operational requirements](#operational-requirements)).
+3. The validation report is posted as a comment on the PR by validate-pr Step 8, authenticated with a fine-grained PAT exposed as `GH_TOKEN` (see [Operational requirements](#operational-requirements)).
 
 ### Layer 2 — Deterministic CI (GitHub Actions)
 
@@ -64,7 +64,7 @@ Current workarounds for re-validation:
   │  implement agent                    │
   │  (TDD + self-check)                 │
   │  Step 9: validate-pr custom agent   │
-  │  → posts report on PR (COPILOT_PAT) │
+  │  → posts report on PR (GH_TOKEN PAT) │
   └──────────┬─────────────────────────┘
              │ Opens PR
              ▼
@@ -87,7 +87,7 @@ Current workarounds for re-validation:
 
 ## Operational requirements
 
-### `COPILOT_PAT` in the `copilot` GitHub Actions environment
+### Fine-grained PAT exposed as `GH_TOKEN` in the `copilot` environment
 
 Validate-pr Step 8 posts the validation report as a PR comment. The cloud
 Copilot agent's default token (and the out-of-the-box `github` MCP
@@ -96,20 +96,22 @@ return `GraphQL: Resource not accessible by integration (addComment)` /
 HTTP 403.
 
 To enable comment posting, a fine-grained PAT is exposed to the agent
-runtime as the `COPILOT_PAT` environment variable:
+runtime as the **`GH_TOKEN`** environment variable. `gh` reads
+`GH_TOKEN` automatically, so any `gh pr comment …` call in the agent's
+shell will use the PAT with no further configuration.
 
 | Item | Value |
 |---|---|
 | PAT type | Fine-grained, repository-scoped to `marcgs/SplitVibe` |
 | PAT permissions | `Pull requests: Read and write`, `Contents: Read`, `Metadata: Read` |
-| Stored as | Environment secret named `COPILOT_PAT` |
+| Stored as | Environment secret named `GH_TOKEN` |
 | Stored in | The **`copilot`** GitHub Actions environment ([Settings → Environments → `copilot`](https://github.com/marcgs/SplitVibe/settings/environments)) |
 
 > **Important:** The cloud Copilot agent only injects secrets from the
 > `copilot` environment into its runtime — **not** repository-level
 > Actions secrets. See
 > [Setting environment variables in Copilot's environment](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#setting-environment-variables-in-copilots-environment).
-> A `COPILOT_PAT` secret stored at the repository level is silently
+> A `GH_TOKEN` secret stored at the repository level is silently
 > invisible to the agent.
 
 PR comments will be authored by the PAT owner (a real GitHub user), not

--- a/docs/adr/002-agentic-ci-workflow.md
+++ b/docs/adr/002-agentic-ci-workflow.md
@@ -29,8 +29,8 @@ We need a workflow that:
 Triggered by assigning a GitHub issue to Copilot (or invoking the implement agent manually).
 
 1. The **implement** agent reads the issue, creates a feature branch, implements via TDD, runs its own validation loop, and opens a PR with `Closes #N`.
-2. In Step 9, the implement agent invokes the **validate-pr** skill within the same coding agent session. This runs in a full VM with Docker, git, npm, and Playwright MCP — providing complete E2E acceptance-criteria validation.
-3. The validation report is posted as a comment on the PR.
+2. In Step 9, the implement agent invokes the **validate-pr** custom agent within the same coding agent session (via the `agent` / `Task` tool — see [Custom agents reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration#tool-aliases)). This runs in a full VM with Docker, git, npm, and Playwright MCP — providing complete E2E acceptance-criteria validation.
+3. The validation report is posted as a comment on the PR by validate-pr Step 8, authenticated with the `COPILOT_PAT` fine-grained PAT (see [Operational requirements](#operational-requirements)).
 
 ### Layer 2 — Deterministic CI (GitHub Actions)
 
@@ -60,12 +60,12 @@ Current workarounds for re-validation:
   Issue assigned to Copilot
          │
          ▼
-  ┌──────────────────────────┐
-  │  implement agent          │
-  │  (TDD + self-check)       │
-  │  Step 9: validate-pr skill│
-  │  → posts report on PR     │
-  └──────────┬───────────────┘
+  ┌────────────────────────────────────┐
+  │  implement agent                    │
+  │  (TDD + self-check)                 │
+  │  Step 9: validate-pr custom agent   │
+  │  → posts report on PR (COPILOT_PAT) │
+  └──────────┬─────────────────────────┘
              │ Opens PR
              ▼
   ┌─────────────────────────────────┐
@@ -82,6 +82,39 @@ Current workarounds for re-validation:
     check      human review
     fails PR
 ```
+
+---
+
+## Operational requirements
+
+### `COPILOT_PAT` in the `copilot` GitHub Actions environment
+
+Validate-pr Step 8 posts the validation report as a PR comment. The cloud
+Copilot agent's default token (and the out-of-the-box `github` MCP
+server's token) is **read-only on pull requests** — attempts to comment
+return `GraphQL: Resource not accessible by integration (addComment)` /
+HTTP 403.
+
+To enable comment posting, a fine-grained PAT is exposed to the agent
+runtime as the `COPILOT_PAT` environment variable:
+
+| Item | Value |
+|---|---|
+| PAT type | Fine-grained, repository-scoped to `marcgs/SplitVibe` |
+| PAT permissions | `Pull requests: Read and write`, `Contents: Read`, `Metadata: Read` |
+| Stored as | Environment secret named `COPILOT_PAT` |
+| Stored in | The **`copilot`** GitHub Actions environment ([Settings → Environments → `copilot`](https://github.com/marcgs/SplitVibe/settings/environments)) |
+
+> **Important:** The cloud Copilot agent only injects secrets from the
+> `copilot` environment into its runtime — **not** repository-level
+> Actions secrets. See
+> [Setting environment variables in Copilot's environment](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#setting-environment-variables-in-copilots-environment).
+> A `COPILOT_PAT` secret stored at the repository level is silently
+> invisible to the agent.
+
+PR comments will be authored by the PAT owner (a real GitHub user), not
+by `copilot-swe-agent[bot]`. Rotate the PAT before its expiration to
+avoid a sudden return of HTTP 403 on validation runs.
 
 ---
 


### PR DESCRIPTION
## Problem

After #72 the implement-agent successfully invokes validate-pr-agent in the cloud Copilot session, validate-pr-agent runs all checks end-to-end, but the **final step (posting the report to the PR) fails** with:

```
GraphQL: Resource not accessible by integration (addComment)
```

Both `gh pr comment` and the `github` MCP server return HTTP 403 because the cloud agent's default token is read-only on pull requests.

## Fix (no code changes required)

A fine-grained PAT (`Pull requests: Read and write` on this repo) is exposed to the agent runtime as the **`GH_TOKEN`** environment variable, stored as an environment secret in the **`copilot`** GitHub Actions environment.

Why `GH_TOKEN` and not `COPILOT_PAT`: `gh` reads `GH_TOKEN` automatically from the environment, so any `gh pr comment …` call in the agent's shell uses the PAT with **no instructional changes** to validate-pr.agent.md.

Why the **`copilot`** environment specifically: per [GitHub docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#setting-environment-variables-in-copilots-environment), the cloud Copilot agent only injects secrets from this environment into its runtime — repo-level Actions secrets are silently invisible to the agent (which was the root cause of the previous failed PAT attempt).

## Changes

- `docs/adr/002-agentic-ci-workflow.md`:
  - Layer 1 description and flow diagram: clarify validate-pr is invoked as a custom agent (not a 'skill') via the `agent` / `Task` tool; report posted with `GH_TOKEN` PAT.
  - New 'Operational requirements' section documents the PAT setup and the `copilot`-environment gotcha.

## Required out-of-band setup (already done)

- Fine-grained PAT created with `Pull requests: Read and write` + `Contents: Read` + `Metadata: Read` on `marcgs/SplitVibe`.
- Stored as secret **`GH_TOKEN`** in the **`copilot`** GitHub Actions environment of this repo.

## Verification

Trigger an implement-agent run on any open issue. Look for:
- A validation report comment posted by the PAT owner (`marcgs`) on the resulting PR.
- Re-runs simply create new comments (the agent doc retains its original prose; comment de-duplication wasn't part of the original behavior either).