### PR TITLE
docs: update README to use bin/sv CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,37 @@ The container includes Node.js 20, Docker, GitHub CLI, Azure CLI, and Playwright
 
 ## Local Development
 
+All engineering workflows go through the `bin/sv` CLI. Run `bin/sv --help` to list every command.
+
 ```bash
 npm install            # first time only
-bin/dev                # starts docker services, runs migrations, launches dev server
-                       # ctrl+c stops everything and cleans up containers
+bin/sv up              # start backend services (docker + db + migrations)
+bin/sv serve           # start Next.js dev server
+bin/sv down            # tear down backend services and kill port 3000
 ```
 
 ## Testing
 
 ```bash
-bin/test               # unit/integration tests
-bin/test --watch       # watch mode
-bin/test --e2e         # Playwright e2e tests
-bin/test path/to/file  # specific file
+bin/sv test                   # unit/integration tests
+bin/sv test --watch           # watch mode
+bin/sv test --e2e             # Playwright e2e tests
+bin/sv test path/to/file      # specific file
 ```
 
 ## Quality Checks
 
 ```bash
-bin/lint               # typecheck + lint
-bin/check              # full CI gate (typecheck + lint + tests)
+bin/sv lint                   # typecheck + lint (project-wide)
+bin/sv lint path/to/file.ts   # typecheck + lint a single file
+bin/sv check                  # full CI gate (typecheck + lint + tests)
+```
+
+## Documentation
+
+```bash
+bin/sv docs                   # list available doc topics
+bin/sv docs <topic>           # print doc content to stdout
 ```
 
 ## Deployment
@@ -56,10 +67,11 @@ bin/check              # full CI gate (typecheck + lint + tests)
 Deploys to **Azure Container Apps** via GitHub Actions on push to `main`.
 
 ```bash
-bin/infra dev          # provision Azure infrastructure (first time)
-bin/infra prod         # provision prod infrastructure
-bin/deploy dev         # build, push, and deploy app to dev
-bin/deploy prod        # build, push, and deploy app to prod
+bin/sv infra dev       # provision Azure infrastructure (first time)
+bin/sv infra prod      # provision prod infrastructure
+bin/sv deploy dev      # build, push, and deploy app to dev
+bin/sv deploy prod     # build, push, and deploy app to prod
+bin/sv domain dev      # bind custom domain + TLS (dev|prod)
 ```
 
 Required environment variables (set in `.env`):


### PR DESCRIPTION
The README still referenced the old per-script binaries (`bin/dev`, `bin/test`, `bin/lint`, `bin/check`, `bin/infra`, `bin/deploy`). All engineering workflows now go through the unified `bin/sv` CLI.

## Changes

- Local Development: `bin/dev` → `bin/sv up` + `bin/sv serve` (+ `bin/sv down`)
- Testing: `bin/test ...` → `bin/sv test ...`
- Quality Checks: `bin/lint` / `bin/check` → `bin/sv lint` / `bin/sv check`
- Deployment: `bin/infra` / `bin/deploy` → `bin/sv infra` / `bin/sv deploy` (+ added `bin/sv domain`)
- Added a Documentation section for `bin/sv docs`
- Noted up front that `bin/sv --help` lists every command